### PR TITLE
앨범 이미지 저장 및 7일 후 삭제 기능 구현

### DIFF
--- a/src/main/java/com/dearnewyear/dny/album/domain/Album.java
+++ b/src/main/java/com/dearnewyear/dny/album/domain/Album.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -73,6 +74,7 @@ public class Album {
 
     @Field(name = "created_at")
     @CreatedDate
+    @Indexed(expireAfter = "7d")
     private LocalDateTime createdAt;
 
     public void updateTo(String toUserId) {

--- a/src/main/java/com/dearnewyear/dny/album/domain/Album.java
+++ b/src/main/java/com/dearnewyear/dny/album/domain/Album.java
@@ -65,11 +65,9 @@ public class Album {
     private String letter;
 
     @Field(name = "front_image")
-    @NotNull
     private String frontImage;
 
     @Field(name = "back_image")
-    @NotNull
     private String backImage;
 
     @Field(name = "created_at")

--- a/src/main/java/com/dearnewyear/dny/album/dto/AlbumInfo.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/AlbumInfo.java
@@ -49,6 +49,12 @@ public class AlbumInfo {
     @ApiModelProperty(value = "편지 내용")
     private final String letter;
 
+    @ApiModelProperty(value = "앨범 앞면 이미지")
+    private final String frontImage;
+
+    @ApiModelProperty(value = "앨범 뒷면 이미지")
+    private final String backImage;
+
     public AlbumInfo(Album album, Music music) {
         this.albumId = album.getAlbumId();
         this.albumCover = album.getAlbumCover().name();
@@ -61,5 +67,7 @@ public class AlbumInfo {
         this.fromName = album.getFromName();
         this.toName = album.getToName();
         this.letter = album.getLetter();
+        this.frontImage = album.getFrontImage();
+        this.backImage = album.getBackImage();
     }
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
@@ -5,7 +5,6 @@ import com.dearnewyear.dny.album.domain.constant.AlbumCover;
 import com.dearnewyear.dny.album.domain.constant.AlbumPhrases;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.regex.Pattern;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -33,7 +32,6 @@ public class AlbumRequest {
     @ApiModelProperty(value = "음악 ID", required = true)
     private final String musicId;
 
-    @NotBlank
     @ApiModelProperty(value = "받는 사람 ID")
     private final String toUserId;
 
@@ -68,16 +66,6 @@ public class AlbumRequest {
     @AssertTrue(message = "유효하지 않은 앨범 배경입니다.")
     public boolean isValidAlbumBackground() {
         return AlbumBackground.isValidAlbumBackground(albumBackground);
-    }
-
-    @AssertTrue(message = "음악 ID는 숫자여야 합니다.")
-    public boolean isValidMusicId() {
-        return Pattern.matches("^[0-9]*$", musicId);
-    }
-
-    @AssertTrue(message = "받는 사람 ID는 숫자여야 합니다.")
-    public boolean isValidToUserId() {
-        return Pattern.matches("^[0-9]*$", toUserId);
     }
 
     public AlbumCover getAlbumCover() {

--- a/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @AllArgsConstructor
@@ -47,6 +48,12 @@ public class AlbumRequest {
     @NotBlank
     @ApiModelProperty(value = "편지 내용", required = true)
     private final String letter;
+
+    @ApiModelProperty(value = "앨범 앞면 이미지")
+    private final MultipartFile frontImage;
+
+    @ApiModelProperty(value = "앨범 뒷면 이미지")
+    private final MultipartFile backImage;
 
     @AssertTrue(message = "유효하지 않은 앨범 커버입니다.")
     public boolean isValidAlbumCover() {

--- a/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
+++ b/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
@@ -13,7 +13,6 @@ import com.dearnewyear.dny.music.repository.MusicRepository;
 import com.dearnewyear.dny.user.domain.User;
 import com.dearnewyear.dny.user.repository.UserRepository;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -34,14 +33,10 @@ public class AlbumService {
 
     public AlbumInfo sendAlbum(AlbumRequest albumRequest, HttpServletRequest request) {
         String accessToken = jwtTokenProvider.getAccessToken(request);
-        User fromUser = userRepository.findById(jwtTokenProvider.getUserId(accessToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        String toUserId = albumRequest.getToUserId();
-        User toUser = null;
-        if (toUserId != null)
-            toUser = userRepository.findById(toUserId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User fromUser = findUserById(jwtTokenProvider.getUserId(accessToken));
+        User toUser = findUserByIdOrNull(albumRequest.getToUserId());
+        Music music = findMusicById(albumRequest.getMusicId());
 
         String frontImgName = s3Service.upload(albumRequest.getFrontImage());
         String backImgName = s3Service.upload(albumRequest.getBackImage());
@@ -50,9 +45,9 @@ public class AlbumService {
                 .albumCover(albumRequest.getAlbumCover())
                 .albumPhrases(albumRequest.getAlbumPhrases())
                 .albumBackground(albumRequest.getAlbumBackground())
-                .musicId(albumRequest.getMusicId())
+                .musicId(music.getMusicId())
                 .fromUserId(fromUser.getUserId())
-                .toUserId(toUserId)
+                .toUserId(toUser != null ? toUser.getUserId() : null)
                 .fromName(albumRequest.getFromName())
                 .toName(albumRequest.getToName())
                 .letter(albumRequest.getLetter())
@@ -64,53 +59,45 @@ public class AlbumService {
     }
 
     public AlbumInfo viewAlbum(String albumId, HttpServletRequest request) {
-        Album album = albumRepository.findById(albumId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
-
         String accessToken = jwtTokenProvider.getAccessToken(request);
+
+        Album album = findAlbumById(albumId);
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         checkAlbumPermission(album, authentication);
 
-        return new AlbumInfo(album, musicRepository.findById(album.getMusicId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MUSIC_NOT_FOUND)));
+        return new AlbumInfo(album, findMusicById(album.getMusicId()));
     }
 
     public List<AlbumInfo> viewCollection(HttpServletRequest request) {
         String accessToken = jwtTokenProvider.getAccessToken(request);
-        User user = userRepository.findById(jwtTokenProvider.getUserId(accessToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        User user = findUserById(jwtTokenProvider.getUserId(accessToken));
         List<Album> albumList = albumRepository.findByToUserId(user.getUserId());
         return albumList.stream()
-                .map(album -> new AlbumInfo(album, musicRepository.findById(album.getMusicId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.MUSIC_NOT_FOUND)))
-                ).collect(Collectors.toList());
+                .map(album -> new AlbumInfo(album, findMusicById(album.getMusicId())))
+                .collect(Collectors.toList());
     }
 
     public void addAlbumToCollection(String albumId, HttpServletRequest request) {
-        Album album = albumRepository.findById(albumId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
+        String accessToken = jwtTokenProvider.getAccessToken(request);
+
+        Album album = findAlbumById(albumId);
         if (album.getToUserId() != null)
             throw new CustomException(ErrorCode.ALBUM_NOT_AUTHORIZED);
 
-        String accessToken = jwtTokenProvider.getAccessToken(request);
-        User user = userRepository.findById(jwtTokenProvider.getUserId(accessToken))
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        User user = findUserById(jwtTokenProvider.getUserId(accessToken));
         album.updateTo(user.getUserId());
+        albumRepository.save(album);
     }
 
     private void checkAlbumPermission(Album album, Authentication authentication) {
         if (album.getToUserId() == null)
             return;
 
-        Optional<User> fromUser = userRepository.findById(album.getFromUserId());
-        Optional<User> toUser = userRepository.findById(album.getToUserId());
+        User fromUser = findUserById(album.getFromUserId());
+        User toUser = findUserByIdOrNull(album.getToUserId());
 
-        if (fromUser == null)
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
-
-        if (!isFromUser(fromUser.get(), authentication) && !isToUser(toUser.get(), authentication))
+        if (!isFromUser(fromUser, authentication) && (toUser != null && !isToUser(toUser, authentication)))
             throw new CustomException(ErrorCode.ALBUM_NOT_AUTHORIZED);
     }
 
@@ -120,5 +107,24 @@ public class AlbumService {
 
     private boolean isToUser(User toUser, Authentication authentication) {
         return toUser.getUserName().equals(authentication.getName());
+    }
+
+    public User findUserById(String userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public User findUserByIdOrNull(String userId) {
+        return userId != null ? findUserById(userId) : null;
+    }
+
+    public Music findMusicById(String musicId) {
+        return musicRepository.findById(musicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MUSIC_NOT_FOUND));
+    }
+
+    public Album findAlbumById(String albumId) {
+        return albumRepository.findById(albumId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ALBUM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
+++ b/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
@@ -7,6 +7,7 @@ import com.dearnewyear.dny.album.repository.AlbumRepository;
 import com.dearnewyear.dny.common.error.ErrorCode;
 import com.dearnewyear.dny.common.error.exception.CustomException;
 import com.dearnewyear.dny.common.jwt.JwtTokenProvider;
+import com.dearnewyear.dny.common.service.S3Service;
 import com.dearnewyear.dny.music.domain.Music;
 import com.dearnewyear.dny.music.repository.MusicRepository;
 import com.dearnewyear.dny.user.domain.User;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlbumService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final S3Service s3Service;
     private final UserRepository userRepository;
     private final AlbumRepository albumRepository;
     private final MusicRepository musicRepository;
@@ -41,8 +43,8 @@ public class AlbumService {
             toUser = userRepository.findById(toUserId)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Music music = musicRepository.findById(albumRequest.getMusicId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MUSIC_NOT_FOUND));
+        String frontImgName = s3Service.upload(albumRequest.getFrontImage());
+        String backImgName = s3Service.upload(albumRequest.getBackImage());
 
         Album album = Album.builder()
                 .albumCover(albumRequest.getAlbumCover())
@@ -54,6 +56,8 @@ public class AlbumService {
                 .fromName(albumRequest.getFromName())
                 .toName(albumRequest.getToName())
                 .letter(albumRequest.getLetter())
+                .frontImage(frontImgName)
+                .backImage(backImgName)
                 .build();
         albumRepository.save(album);
         return new AlbumInfo(album, music);

--- a/src/main/java/com/dearnewyear/dny/music/domain/Music.java
+++ b/src/main/java/com/dearnewyear/dny/music/domain/Music.java
@@ -17,7 +17,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class Music {
 
     @Id
-    private Long musicId;
+    private String musicId;
 
     @Field(name = "music_name")
     @NotNull

--- a/src/main/java/com/dearnewyear/dny/music/dto/MusicInfo.java
+++ b/src/main/java/com/dearnewyear/dny/music/dto/MusicInfo.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 public class MusicInfo {
 
     @ApiModelProperty(value = "음악 ID")
-    private final Long musicId;
+    private final String musicId;
 
     @ApiModelProperty(value = "음악 이름")
     private final String musicName;


### PR DESCRIPTION
### Issue No.

#44 
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x] 앨범 이미지 저장 구현
  - [x] 스키마에 앞, 뒤 이미지 추가
  - [x] S3 다시 세팅
- [x] TTL (7일 후 삭제)
- [x] 이외 약간의 코드 리팩


<br/>